### PR TITLE
Remove database functionality from pairbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pairs random users in a Slack channel every two weeks.
 
-You've provided a Python script designed to randomly pair members in a Slack channel and announce these pairs, while also keeping track of recent pairings to avoid repetition. This is a great tool for fostering team connections\!
+You've provided a Python script designed to randomly pair members in a Slack channel and announce these pairs. This is a great tool for fostering team connections\!
 
 Here's a **markdown version** of the `README.md` file for your code:
 
@@ -10,14 +10,13 @@ Here's a **markdown version** of the `README.md` file for your code:
 
 # Slack Pair Bot
 
-This Python script is a simple bot that facilitates team bonding by randomly pairing members within a specified Slack channel. It ensures that recent pairings aren't immediately repeated, encouraging broader interaction among team members.
+This Python script is a simple bot that facilitates team bonding by randomly pairing members within a specified Slack channel.
 
 -----
 
 ## Features
 
   * **Random Pair Generation**: Shuffles and pairs available Slack channel members.
-  * **Pairing History**: Uses a SQLite database to remember past pairings and avoids repeating them within a configurable timeframe (default: 4 weeks).
   * **Slack Integration**: Posts the newly generated pairs directly into your designated Slack channel.
   * **Bot Exclusion**: Automatically excludes the bot's own user ID and the generic Slackbot from pairing.
 
@@ -101,12 +100,10 @@ python your_script_name.py
 
 The script will:
 
-1.  Initialize a SQLite database (`pairs.db`) if it doesn't exist.
-2.  Fetch all members from the specified `SLACK_CHANNEL_ID`.
-3.  Filter out the bot itself and the `USLACKBOT`.
-4.  Generate new pairs, avoiding those made in the last 4 weeks (by default).
-5.  Save the new pairs to the database.
-6.  Post each generated pair to the Slack channel.
+1.  Fetch all members from the specified `SLACK_CHANNEL_ID`.
+2.  Filter out the bot itself and the `USLACKBOT`.
+3.  Generate random pairs from the available members.
+4.  Post each generated pair to the Slack channel.
 
 ### Running Automatically (e.g., with Cron)
 
@@ -119,25 +116,6 @@ You can schedule this script to run periodically (e.g., weekly) using tools like
 ```
 
 Make sure the full path to your Python executable and script is correct. Also, ensure that the environment variables (`SLACK_BOT_TOKEN`, `SLACK_CHANNEL_ID`) are set in the cron environment or hardcoded within the script (though environment variables are preferred for security).
-
------
-
-## Database
-
-The script uses a **SQLite database** named `pairs.db` to store past pairings. This allows the bot to remember who has been paired with whom and avoid immediate repetitions.
-
-  * **File**: `pairs.db`
-  * **Table**: `pairs`
-  * **Columns**:
-      * `user1` (TEXT): ID of the first user in a pair.
-      * `user2` (TEXT): ID of the second user in a pair.
-      * `timestamp` (INTEGER): Unix timestamp when the pair was created.
-
------
-
-## Customization
-
-  * **Recent Pairs Window**: By default, the bot remembers pairs for the last 4 weeks. You can adjust this by modifying the `weeks` parameter in the `get_recent_pairs` function call within `main()`.
 
 -----
 

--- a/slack_pair_bot.py
+++ b/slack_pair_bot.py
@@ -1,31 +1,14 @@
 import os
 import random
-import sqlite3
-import time
 import requests
 
 SLACK_TOKEN = os.getenv("SLACK_BOT_TOKEN")
 CHANNEL_ID = os.getenv("SLACK_CHANNEL_ID")
-DB_FILE = "pairs.db"
 
 headers = {
     "Authorization": f"Bearer {SLACK_TOKEN}",
     "Content-Type": "application/json",
 }
-
-def init_db():
-    print("[DEBUG] Initializing DB")
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    c.execute("""
-        CREATE TABLE IF NOT EXISTS pairs (
-            user1 TEXT,
-            user2 TEXT,
-            timestamp INTEGER
-        )
-    """)
-    conn.commit()
-    conn.close()
 
 def get_bot_user_id():
     resp = requests.get("https://slack.com/api/auth.test", headers=headers).json()
@@ -37,25 +20,6 @@ def get_channel_members():
     resp = requests.get(url, headers=headers).json()
     print("[DEBUG] Slack API members response:", resp)
     return resp.get("members", [])
-
-def get_recent_pairs(weeks=4):
-    cutoff = int(time.time()) - weeks * 7 * 24 * 3600
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    c.execute("SELECT user1, user2 FROM pairs WHERE timestamp > ?", (cutoff,))
-    pairs = c.fetchall()
-    conn.close()
-    return set(tuple(sorted(p)) for p in pairs)
-
-def save_pairs(pairs):
-    print("[DEBUG] Saving pairs:", pairs)
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    now = int(time.time())
-    for u1, u2 in pairs:
-        c.execute("INSERT INTO pairs (user1, user2, timestamp) VALUES (?, ?, ?)", (u1, u2, now))
-    conn.commit()
-    conn.close()
 
 def post_pairs_to_slack(pairs):
     print("[DEBUG] Posting pairs to Slack")
@@ -69,27 +33,23 @@ def post_pairs_to_slack(pairs):
         )
         print("[DEBUG] Slack response:", resp.json())
 
-def generate_pairs(members, recent_pairs):
+def generate_pairs(members):
     random.shuffle(members)
     pairs = []
     while len(members) >= 2:
         u1, u2 = members.pop(), members.pop()
-        if tuple(sorted((u1, u2))) not in recent_pairs:
-            pairs.append((u1, u2))
+        pairs.append((u1, u2))
     return pairs
 
 def main():
-    init_db()
     bot_id = get_bot_user_id()
     members = get_channel_members()
     members = [m for m in members if m != "USLACKBOT" and m != bot_id]
     print("[DEBUG] Members after filtering:", members)
-    recent = get_recent_pairs()
-    pairs = generate_pairs(members, recent)
+    pairs = generate_pairs(members)
     if not pairs:
         print("[DEBUG] No valid pairs found. Skipping post.")
         return
-    save_pairs(pairs)
     post_pairs_to_slack(pairs)
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Removed sqlite3 import and database-related functions
- Removed init_db(), get_recent_pairs(), and save_pairs() functions
- Simplified generate_pairs() to not consider recent pairings
- Updated main() to remove database initialization and saving
- Updated README.md to remove references to database functionality
- Bot now generates purely random pairs without history tracking